### PR TITLE
Add include_dirs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Full list of options you can change to your taste, you can always fire `rebar3 h
     {out_erl_dir, "src"},
     % Directory to put all generated *.hrl files into, relative to application output directory
     {out_hrl_dir, "include"},
+    % List of directories searched for include directives
+    {include_dirs, []},
     % Generator (with arbitrary flags) to use when compiling *.thrift files
     {gen, "erl:legacy_names"}
 ]}.

--- a/src/rebar3_thrift_compiler_prv.erl
+++ b/src/rebar3_thrift_compiler_prv.erl
@@ -121,8 +121,13 @@ get_all_opts(AppInfo, CmdOpts, State) ->
     RootDir    = rebar_dir:root_dir(State),
     DepsDir    = rebar_dir:deps_dir(State),
     AbsDepsDir = filename:join(RootDir, DepsDir),
-    Deps       = [ join(AbsDepsDir, Dep) || Dep <- rebar_app_info:deps(AppInfo) ],
-    append_list(include_dirs, [AbsDepsDir | Deps], Opts).
+    DepNames   = rebar_app_info:deps(AppInfo),
+    DepPathes  = [
+        rebar_app_info:dir(App) ||
+        App <- rebar_state:all_deps(State),
+        true == lists:member(rebar_app_info:name(App), DepNames)
+    ],
+    append_list(include_dirs, [AbsDepsDir | DepPathes], Opts).
 
 get_all_opts(AppInfo, {CmdOpts0, InFiles}) ->
     DefOpts = get_default_opts(),
@@ -208,12 +213,3 @@ get_canonical_paths(Paths) ->
 append_list(Key, Value, Opts) ->
     {Key, Old} = lists:keyfind(Key, 1, Opts),
     lists:keystore(Key, 1, Opts, {Key, Old ++ Value}).
-
-join(Dir1, Dir2) ->
-    Dir = filename:join(Dir1, Dir2),
-    ensure_string(Dir).
-
-ensure_string(S) when is_list(S) ->
-    S;
-ensure_string(B) when is_binary(B) ->
-    binary_to_list(B).

--- a/src/rebar3_thrift_compiler_prv.erl
+++ b/src/rebar3_thrift_compiler_prv.erl
@@ -122,7 +122,7 @@ get_all_opts(AppInfo, CmdOpts, State) ->
     DepsDir    = rebar_dir:deps_dir(State),
     AbsDepsDir = filename:join(RootDir, DepsDir),
     DepNames   = rebar_app_info:deps(AppInfo),
-    DepPathes  = [
+    DepPaths   = [
         rebar_app_info:dir(App) ||
         App <- rebar_state:all_deps(State),
         true == lists:member(rebar_app_info:name(App), DepNames)

--- a/src/rebar3_thrift_compiler_prv_compile.erl
+++ b/src/rebar3_thrift_compiler_prv_compile.erl
@@ -33,7 +33,7 @@ init(State) ->
             "    {in_files, [\"file1.thrift\", ...]}, % explicit list of files to compile\n"
             "    {out_erl_dir, \"src\"},              % where *.erl files fall\n"
             "    {out_hrl_dir, \"include\"},          % where *.hrl files fall\n"
-            "    {include_dirs, []]},                 % list of directories searched for includes\n"
+            "    {include_dirs, []},                % list of directories searched for includes\n"
             "    {gen, \"erl:legacy_names\"}          % what generator to invoke\n"
             "  ]}."
             "\n"

--- a/src/rebar3_thrift_compiler_prv_compile.erl
+++ b/src/rebar3_thrift_compiler_prv_compile.erl
@@ -33,6 +33,7 @@ init(State) ->
             "    {in_files, [\"file1.thrift\", ...]}, % explicit list of files to compile\n"
             "    {out_erl_dir, \"src\"},              % where *.erl files fall\n"
             "    {out_hrl_dir, \"include\"},          % where *.hrl files fall\n"
+            "    {include_dirs, []]},                 % list of directories searched for includes\n"
             "    {gen, \"erl:legacy_names\"}          % what generator to invoke\n"
             "  ]}."
             "\n"
@@ -69,7 +70,7 @@ do(State) ->
     rebar_hooks:run_all_hooks(Cwd, pre, thrift, Providers, State),
     CmdOpts = rebar_state:command_parsed_args(State),
     ok = lists:foreach(
-        fun (AppInfo) -> rebar3_thrift_compiler_prv:compile(AppInfo, CmdOpts) end,
+        fun (AppInfo) -> rebar3_thrift_compiler_prv:compile(AppInfo, CmdOpts, State) end,
         get_apps(State)
     ),
     {ok, State}.


### PR DESCRIPTION
This changeset adds `include_dirs` option which in addition appended with dependencies directory (lib) of current profile plus each dependency of current compiling library.