### PR TITLE
Added macro for both OTP 21 and OTP 19 compatibility

### DIFF
--- a/src/otp_19_compatibility.hrl
+++ b/src/otp_19_compatibility.hrl
@@ -1,0 +1,10 @@
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE >= 21).
+-define(STACKTRACE(ErrorType, Error, ErrorStackTrace),
+        ErrorType:Error:ErrorStackTrace ->).
+-endif.
+-else.
+-define(STACKTRACE(ErrorType, Error, ErrorStackTrace),
+        ErrorType:Error ->
+            ErrorStackTrace = erlang:get_stacktrace(),).
+-endif.

--- a/src/rebar3_thrift_compiler_prv.erl
+++ b/src/rebar3_thrift_compiler_prv.erl
@@ -1,5 +1,7 @@
 -module(rebar3_thrift_compiler_prv).
 
+-include("otp_19_compatibility.hrl").
+
 -export([compile/3]).
 -export([clean/2]).
 
@@ -22,10 +24,10 @@ compile(AppInfo, CmdOpts, State) ->
     try
         ok = compile_files(InFiles, OutDirs, Opts),
         ok = distribute_files(OutDirs)
-    catch C:E ->
+    catch ?STACKTRACE(C, E, Stacktrace)
         % is it ok for now to depend on the fact that rebar aborts via exceptions?
         _ = cleanup(OutDirs),
-        erlang:raise(C, E, erlang:get_stacktrace())
+        erlang:raise(C, E, Stacktrace)
     end.
 
 -spec clean(rebar_app_info:t(), command_args()) -> ok.


### PR DESCRIPTION
Feature request от @keynslug 
Макрос для получения `Stacktrace`, позволяющий без использовать код как с  `Erlang OTP 19` так и с `OTP 21` без варнингов.